### PR TITLE
switch back to concourse/buildroot image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.8
+FROM concourse/buildroot:git
 
-RUN apk --no-cache add openssh-client bash curl git jq coreutils
+RUN apk --no-cache add coreutils
 
 COPY scripts/ /opt/resource/
 RUN chmod +x /opt/resource/*


### PR DESCRIPTION
This should hopefully fix some of the problems introduced by the update I made to the resource.

I'm not sure, because I can't work out what `concourse/buildroot:git`'s FROM image is and how it's different, but it was working before so it shouldn't hurt.