### PR TITLE
Properly check out MR branch and set .git/branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM concourse/buildroot:git
+FROM alpine:3.8
 
-RUN apk --no-cache add coreutils
+RUN apk --no-cache add openssh-client bash curl git jq coreutils
+
+# can't `git pull` unless we set these
+RUN git config --global user.email "git@localhost" && \
+      git config --global user.name "git"
 
 COPY scripts/ /opt/resource/
 RUN chmod +x /opt/resource/*

--- a/scripts/in
+++ b/scripts/in
@@ -52,6 +52,9 @@ fi
 git clone "${uri}" "${destination}"
 
 cd "${destination}"
+branch_name="$(git name-rev "${commit_sha}" --name-only | sed -n 's:remotes/origin/::p')"
+git checkout ${branch_name}
+echo ${branch_name} > .git/branch
 
 git reset --hard "${commit_sha}"
 


### PR DESCRIPTION
This fixes the problem several people have been having with `.git/branch` not existing, and also changes the way the resource checks out branches to allow it to properly populate that field.